### PR TITLE
Carrier Numeracy Fix

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/Castes/Carrier.dm
+++ b/code/modules/mob/living/carbon/xenomorph/Castes/Carrier.dm
@@ -30,7 +30,7 @@
 	var/hugger_delay = 30
 	var/eggs_cur = 0
 	var/eggs_max = 3
-	tier = 3
+	tier = 2
 	upgrade = 0
 	pixel_x = -16 //Needed for 2x2
 	old_x = -16


### PR DESCRIPTION
Stops carrier blocking t3 slots despite not checking t3 numbers when evolving itself and being generally out of line with the hivelord and what tier hive status tells you the carrier is in game.

one

TWO

three